### PR TITLE
Update open_manipulator_x.ros2_control.xacro

### DIFF
--- a/open_manipulator_x_description/urdf/open_manipulator_x.ros2_control.xacro
+++ b/open_manipulator_x_description/urdf/open_manipulator_x.ros2_control.xacro
@@ -6,7 +6,7 @@
     <ros2_control name="${name}" type="system">
       <hardware>
         <plugin>dynamixel_hardware/DynamixelHardware</plugin>
-        <param name="usb_port">/dev/ttyUSB0</param>
+        <param name="port_name">/dev/ttyUSB0</param>
         <param name="baud_rate">1000000</param>
         <!-- <param name="use_dummy">true</param> -->
       </hardware>


### PR DESCRIPTION
Changed the name of the param variable from "usb_port" to "port_name" to align with DynamixelSDK.